### PR TITLE
iOSボタン修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,10 @@
  *= require_self
  */
 
+* {
+  -webkit-appearance: none;
+}
+
 body {
   margin: 0;
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
# Why
iPhoneで見るとボタンが角丸になってしまうので、それを解除する。