### PR TITLE
iOSボタンcss全てリセット

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,8 +14,24 @@
  *= require_self
  */
 
-* {
-  -webkit-appearance: none;
+ /* iOSボタンのcssリセット */
+input[type="submit"],
+input[type="button"] {
+  border-radius: 0;
+  -webkit-box-sizing: content-box;
+  -webkit-appearance: button;
+  appearance: button;
+  border: none;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+input[type="submit"]::-webkit-search-decoration,
+input[type="button"]::-webkit-search-decoration {
+  display: none;
+}
+input[type="submit"]::focus,
+input[type="button"]::focus {
+  outline-offset: -2px;
 }
 
 body {


### PR DESCRIPTION
# Why
前回iOSボタンの角丸は除外できたが、それでもテキストがずれてしまっていたりしたので、iOSのcssを全てリセットする。